### PR TITLE
Scale up backend service

### DIFF
--- a/k8s/backend-v1.yaml
+++ b/k8s/backend-v1.yaml
@@ -7,7 +7,7 @@ metadata:
     app: backend
     version: v1
 spec:
-  replicas: 2
+  replicas: 4
   selector:
     matchLabels:
       app: backend


### PR DESCRIPTION
This PR increases the number of replicas for the backend deployment from 2 to 4. This change is intended to accommodate increased load on the application.

### Changes Made
- Increased replicas in `backend-v1.yaml` from 2 to 4.

### Verification Plan
- After PR merge, monitor the deployment status to ensure that all 4 replicas are successfully deployed and running without issues.
- Ensure that the increased replicas handle the load effectively without any resource crunch.