### PR TITLE
Add Ubuntu VM Configuration for GCP

### DIFF
--- a/terraform/compute/ubuntu.tf
+++ b/terraform/compute/ubuntu.tf
@@ -1,0 +1,21 @@
+provider "google" {
+ project = "your-gcp-project-id"
+ region  = "your-gcp-region"
+}
+
+resource "google_compute_instance" "ubuntu-vm" {
+ name         = "ubuntu-vm"
+ machine_type = "e2-medium"
+ zone         = "your-gcp-zone"
+
+ boot_disk {
+  initialize_params {
+   image = "ubuntu-os-cloud/ubuntu-2004-lts"
+  }
+ }
+
+ network_interface {
+  network = "default"
+  access_config {}
+ }
+}


### PR DESCRIPTION
This PR introduces the Terraform configuration for creating an Ubuntu VM on Google Cloud Platform.