### PR TITLE
Add Terraform configuration for Debian Compute VM on GCP

### DIFF
--- a/terraform/compute/debian.tf
+++ b/terraform/compute/debian.tf
@@ -1,0 +1,32 @@
+provider "google" {
+  credentials = file("<YOUR-CREDENTIALS-FILE>")
+  project     = "<YOUR-PROJECT-ID>"
+  region      = "<YOUR-REGION>"
+}
+
+resource "google_compute_instance" "debian_vm" {
+  name         = "debian-vm"
+  machine_type = "e2-medium"
+  zone         = "<YOUR-ZONE>"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9-stretch"
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+      // Ephemeral IP
+    }
+  }
+
+  metadata = {
+    ssh-keys = "admin:${file("~/.ssh/id_rsa.pub")}"
+  }
+
+  service_account {
+    scopes = ["https://www.googleapis.com/auth/compute.readonly"]
+  }
+}


### PR DESCRIPTION
This PR introduces the Terraform configuration necessary for creating a Debian Compute VM on the Google Cloud Platform.

**File Added:**
- `terraform/compute/debian.tf`

Please review the changes and merge if everything is in order.