### PR TITLE
Add Ubuntu VM Terraform Configuration for GCP

### DIFF
--- a/terraform/compute/ubuntu.terraform
+++ b/terraform/compute/ubuntu.terraform
@@ -1,0 +1,32 @@
+provider "google" {
+  credentials = file("<YOUR-CREDENTIALS-FILE>.json")
+  project     = "<YOUR-PROJECT-ID>"
+  region      = "us-central1"
+  zone        = "us-central1-c"
+}
+
+resource "google_compute_instance" "ubuntu-vm" {
+  name         = "ubuntu-vm"
+  machine_type = "e2-medium"
+  zone         = "us-central1-c"
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-os-cloud/ubuntu-2004-lts"
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+    }
+  }
+
+  metadata = {
+    ssh-keys = "ubuntu:${file("<YOUR-PUBLIC-KEY-FILE>.pub")}"
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+}


### PR DESCRIPTION
This pull request includes the necessary Terraform configuration to set up an Ubuntu VM instance on Google Cloud Platform. The setup specifies a standard e2-medium machine type with Ubuntu 20.04 LTS image.

Please review the changes and merge them if everything is correct.