### PR TITLE
Increase Backend Pods Count

### DIFF
--- a/k8s/backend-v1.yaml
+++ b/k8s/backend-v1.yaml
@@ -7,7 +7,7 @@ metadata:
     app: backend
     version: v1
 spec:
-  replicas: 2
+  replicas: 3
   selector:
     matchLabels:
       app: backend
@@ -41,10 +41,4 @@ metadata:
     version: v1
 spec:
   selector:
-    app: backend
-    version: v1
-  ports:
-  - port: 80
-    targetPort: 80
-    protocol: TCP
-  type: ClusterIP
+    app: ...


### PR DESCRIPTION
This PR increases the replica count of the backend deployment from 2 to 3 to improve service availability and handle more traffic. Please review the changes.