### PR TITLE
Increase backend replicas from 2 to 3

### DIFF
--- a/k8s/backend-v1.yaml
+++ b/k8s/backend-v1.yaml
@@ -7,7 +7,7 @@ metadata:
     app: backend
     version: v1
 spec:
-  replicas: 2
+  replicas: 3
   selector:
     matchLabels:
       app: backend


### PR DESCRIPTION
This pull request increases the number of replicas for the backend deployment from 2 to 3, improving its availability and load handling.