### PR TITLE
Bump replica count for hellopy-dev to 5

### DIFF
--- a/k8s/hellopy-dev.yaml
+++ b/k8s/hellopy-dev.yaml
@@ -2,7 +2,7 @@ hellopy-dev:
   name: hellopy-dev
   namespace: hellopy
   project: devel-1234
-  replicaCount: 2
+  replicaCount: 5
   deploymentContainer:
     port: 5000
     command: ['./entrypoint.sh']


### PR DESCRIPTION
This PR increases the replica count for the `hellopy-dev` application from 2 to 5 in the Kubernetes configuration. This change is intended to match the growing needs for the application's capacity.