### PR TITLE
Increase Replicas for hellopy-dev Deployment

### DIFF
--- a/k8s/hellopy-dev.yaml
+++ b/k8s/hellopy-dev.yaml
@@ -2,7 +2,7 @@ hellopy-dev:
   name: hellopy-dev
   namespace: hellopy
   project: devel-1234
-  replicaCount: 2
+  replicaCount: 3
   deploymentContainer:
     port: 5000
     command: ['./entrypoint.sh']


### PR DESCRIPTION
This PR increases the number of replicas for the `hellopy-dev` deployment from 2 to 3 to handle increased traffic. Please review the changes and merge if they meet the requirements.