### PR TITLE
Add Horizontal Pod Autoscaler to backend-v1 deployment

### DIFF
--- a/k8s/backend-v1.yaml
+++ b/k8s/backend-v1.yaml
@@ -30,6 +30,27 @@ spec:
           limits:
             memory: "256Mi"
             cpu: "200m"
+      
+---
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: backend-v1-hpa
+  namespace: demo
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: backend-v1
+  minReplicas: 1
+  maxReplicas: 4
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 50
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This PR adds a Horizontal Pod Autoscaler (HPA) to the `backend-v1` deployment in the demo namespace to address the policy violation concerning the lack of an HPA. The HPA is configured to scale between 1 and 4 replicas based on CPU utilization, targeting an average utilization of 50%. This change ensures the deployment can handle varying loads while complying with internal policy requirements.