### PR TITLE
Fix ErrImagePull and Update Resource Limits for Reports API

### DIFF
--- a/charts/reports/reports-api.yaml
+++ b/charts/reports/reports-api.yaml
@@ -29,14 +29,14 @@ reports-api:
       timeoutSeconds: 1
   image:
     repository: us-central1-docker.pkg.dev/hackathon-2025-af24/davecolab/reports
-    tag: latestv1
+    tag: latest
   resources:
     limits:
-      cpu: 200m
-      memory: 256Mi
+      cpu: 300m
+      memory: 384Mi
     requests:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 150m
+      memory: 192Mi
   ingress:
     enabled: true
     hosts:
@@ -61,4 +61,3 @@ reports-api:
     enabled: true
   env:
     LOG_LEVEL: warning
-


### PR DESCRIPTION
This PR updates the image tag to 'latest' and adjusts the resource limits in the `reports-api.yaml` to address the ErrImagePull error and improve resource allocation. These changes are intended to stabilize the deployment process and ensure that the `reports-api` can run efficiently without encountering pod restarts due to insufficient resources.