### PR TITLE
Fix ImagePullBackOff Error in reports-api

### DIFF
--- a/charts/reports/reports-api.yaml
+++ b/charts/reports/reports-api.yaml
@@ -29,7 +29,7 @@ reports-api:
       timeoutSeconds: 1
   image:
     repository: us-central1-docker.pkg.dev/hackathon-2025-af24/davecolab/reports
-    tag: latestv1
+    tag: latest
   resources:
     limits:
       cpu: 200m
@@ -61,4 +61,3 @@ reports-api:
     enabled: true
   env:
     LOG_LEVEL: warning
-


### PR DESCRIPTION
This PR addresses the ImagePullBackOff issue observed in one of the `reports-api` pods. The error was due to an incorrect image tag (`latestv1`). This fix adjusts the image tag from `latestv1` to `latest` to ensure the image can be pulled successfully.