### PR TITLE
Fix ImagePullBackOff Issue: Correct Image Tag for reports-api

### DIFF
--- a/charts/reports/reports-api.yaml
+++ b/charts/reports/reports-api.yaml
@@ -29,7 +29,7 @@ reports-api:
       timeoutSeconds: 1
   image:
     repository: us-central1-docker.pkg.dev/hackathon-2025-af24/davecolab/reports
-    tag: latestv1
+    tag: latest
   resources:
     limits:
       cpu: 200m
@@ -61,4 +61,3 @@ reports-api:
     enabled: true
   env:
     LOG_LEVEL: warning
-


### PR DESCRIPTION
This PR resolves the `ImagePullBackOff` issue in the `reports-api` deployment within the `reports` namespace by correcting the image tag from `latestv1` to `latest`. This change ensures the correct image can be pulled for deployment, addressing the pod startup failure.

**Changes:**
- Corrected image tag in the `charts/reports/reports-api.yaml` configuration.

This fix promotes better stability and reliability for the deployment process.

### Action:
Please review and merge to rectify the pod deployment issue.