### PR TITLE
Fix ImagePullBackOff for reports-api in reports

### DIFF
--- a/charts/reports/reports-api.yaml
+++ b/charts/reports/reports-api.yaml
@@ -30,6 +30,7 @@ reports-api:
   image:
     repository: us-central1-docker.pkg.dev/hackathon-2025-af24/davecolab/reports
     tag: latestv1
+    imagePullSecrets: [{name: reports-api-docker}]
   resources:
     limits:
       cpu: 200m
@@ -61,4 +62,3 @@ reports-api:
     enabled: true
   env:
     LOG_LEVEL: warning
-


### PR DESCRIPTION
This PR addresses the ImagePullBackOff issue encountered by the reports-api deployment in the reports namespace by adding `imagePullSecrets` to ensure proper access to the Docker registry.

The imagePullSecrets named `reports-api-docker` has been added to allow credentials to be supplied for Docker image pulling operation.