### PR TITLE
Fix: Correct image tag for reports-api to resolve ImagePullBackOff

### DIFF
--- a/charts/reports/reports-api.yaml
+++ b/charts/reports/reports-api.yaml
@@ -29,7 +29,7 @@ reports-api:
       timeoutSeconds: 1
   image:
     repository: us-central1-docker.pkg.dev/hackathon-2025-af24/davecolab/reports
-    tag: latestv1
+    tag: latest
   resources:
     limits:
       cpu: 200m
@@ -61,4 +61,3 @@ reports-api:
     enabled: true
   env:
     LOG_LEVEL: warning
-


### PR DESCRIPTION
This PR corrects the image tag from 'latestv1' to 'latest' for the reports-api deployment, resolving the ImagePullBackOff issue.

Changes made:
- Updated image tag in `reports-api.yaml`

This update ensures the deployment can successfully pull the specified image from the repository.